### PR TITLE
Include support for bubbles to be displayed above input fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,30 @@ Bubbles are intended to be displayed on focus.  In the follwing example, the con
 }
 
 ```
+Bubbles can also be displayed above content.
+
+
+```html
+<div id="validation-message" class="bubble-above bubble-show">
+	<span>A validation message.</span>
+</div>
+<input type="text" aria-invalid="true" aria-describedby="validation-message" />
+```
+
+```scss
+.bubble-above {
+	@include vui-validation-bubble;
+}
+
+.bubble-show {
+	@include vui-validation-bubble-show;
+}
+
+.bubble > span {
+	@include vui-validation-bubble-content-above;
+}
+
+```
 
 **Important:** form elements should be marked up to provide validation information that is available to assistive technology, for example, by using `aria-invalid`, `aria-required`, and `aria-describedby`.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Bubbles can also be displayed above content.
 	@include vui-validation-bubble-show;
 }
 
-.bubble > span {
+.bubble-above > span {
 	@include vui-validation-bubble-content-above;
 }
 

--- a/bower.json
+++ b/bower.json
@@ -15,5 +15,8 @@
   "dependencies": {
     "vui-colors": "^0.2.0",
     "vui-typography": "^2.0.1"
+  },
+  "devDependencies": {
+    "vui-input": "^1.5.1"
   }
 }

--- a/test/bubble.html
+++ b/test/bubble.html
@@ -42,6 +42,15 @@
 						</div>
 					</td>
 				</tr>
+				<tr class="above">
+					<th>Above</th>
+					<td style="position:relative">
+						<div class="bubble bubble-show">
+							<span class="bubble-content-above">Grumpy wizards make toxic brew for the evil Queen and Jack. Grumpy wizards make toxic brew for the evil Queen and Jack.Grumpy wizards make toxic brew for the evil Queen and Jack. Grumpy wizards make toxic brew for the evil Queen and Jack.</span>
+						</div>
+						<input type="text" class="invalid-focus" >
+					</td>
+				</tr>
 			</tbody>
 		</table>
 
@@ -79,6 +88,15 @@
 						<div class="bubble bubble-show">
 							<span class="bubble-content">Grumpy wizards make toxic brew for the evil Queen and Jack. Grumpy wizards make toxic brew for the evil Queen and Jack.</span>
 						</div>
+					</td>
+				</tr>
+				<tr class="above">
+					<th>Above</th>
+					<td>
+						<div class="bubble bubble-show">
+							<span class="bubble-content-above">Grumpy wizards make toxic brew for the evil Queen and Jack. Grumpy wizards make toxic brew for the evil Queen and Jack.Grumpy wizards make toxic brew for the evil Queen and Jack. Grumpy wizards make toxic brew for the evil Queen and Jack.</span>
+						</div>
+						<input type="text" class="invalid-focus" >
 					</td>
 				</tr>
 			</tbody>

--- a/test/bubble.html
+++ b/test/bubble.html
@@ -46,7 +46,7 @@
 					<th>Above</th>
 					<td style="position:relative">
 						<div class="bubble bubble-show">
-							<span class="bubble-content-above">Grumpy wizards make toxic brew for the evil Queen and Jack. Grumpy wizards make toxic brew for the evil Queen and Jack.Grumpy wizards make toxic brew for the evil Queen and Jack. Grumpy wizards make toxic brew for the evil Queen and Jack.</span>
+							<span class="bubble-content-above">Grumpy wizards make toxic brew for the evil Queen and Jack. Grumpy wizards make toxic brew for the evil Queen and Jack.</span>
 						</div>
 						<input type="text" class="invalid-focus" >
 					</td>
@@ -94,13 +94,12 @@
 					<th>Above</th>
 					<td>
 						<div class="bubble bubble-show">
-							<span class="bubble-content-above">Grumpy wizards make toxic brew for the evil Queen and Jack. Grumpy wizards make toxic brew for the evil Queen and Jack.Grumpy wizards make toxic brew for the evil Queen and Jack. Grumpy wizards make toxic brew for the evil Queen and Jack.</span>
+							<span class="bubble-content-above">Grumpy wizards make toxic brew for the evil Queen and Jack. Grumpy wizards make toxic brew for the evil Queen and Jack.</span>
 						</div>
 						<input type="text" class="invalid-focus" >
 					</td>
 				</tr>
 			</tbody>
 		</table>
-
 	</body>
 </html>

--- a/test/test.scss
+++ b/test/test.scss
@@ -16,6 +16,9 @@ table {
 tr {
 	height: 5rem;
 }
+tr.above {
+	height: 22rem;
+}
 td, th {
 	padding: 0.5rem;
 }
@@ -30,4 +33,8 @@ td, th {
 
 .bubble-content {
 	@include vui-validation-bubble-content;
+}
+
+.bubble-content-above {
+	@include vui-validation-bubble-content-above;
 }

--- a/test/test.scss
+++ b/test/test.scss
@@ -1,4 +1,5 @@
 @import 'bower_components/vui-typography/typography.scss';
+@import 'bower_components/vui-input/input.scss';
 @import '../validation.scss';
 
 html {
@@ -21,6 +22,14 @@ tr.above {
 }
 td, th {
 	padding: 0.5rem;
+}
+
+input,
+input[type="text"],
+input[type="password"],
+input[type="email"],
+input[type="url"] {
+  @include vui-input;
 }
 
 .bubble {

--- a/validation.css.scss
+++ b/validation.css.scss
@@ -11,3 +11,7 @@
 .vui-validation-bubble-content {
 	@include vui-validation-bubble-content;
 }
+
+.vui-validation-bubble-content-above {
+	@include vui-validation-bubble-content-above;
+}

--- a/validation.scss
+++ b/validation.scss
@@ -12,7 +12,7 @@
 	display: block;
 }
 
-@mixin vui-validation-bubble-content-base() {
+@mixin _vui-validation-bubble-content() {
 
 	position: absolute;
 	left: -0.5rem;
@@ -51,7 +51,7 @@
 
 @mixin vui-validation-bubble-content() {
 
-	@include vui-validation-bubble-content-base;
+	@include _vui-validation-bubble-content;
 
 	top: 0.25rem;
 
@@ -64,7 +64,7 @@
 
 @mixin vui-validation-bubble-content-above() {
 
-	@include vui-validation-bubble-content-base;
+	@include _vui-validation-bubble-content;
 
 	bottom: 0.25rem;
 

--- a/validation.scss
+++ b/validation.scss
@@ -66,7 +66,7 @@
 
 	@include vui-validation-bubble-content-base;
 
-	bottom: -0.1rem;
+	bottom: 0.25rem;
 
 	&::before {
 		bottom: -0.7rem;

--- a/validation.scss
+++ b/validation.scss
@@ -12,10 +12,9 @@
 	display: block;
 }
 
-@mixin vui-validation-bubble-content() {
+@mixin vui-validation-bubble-content-base() {
 
 	position: absolute;
-	top: 0.25rem;
 	left: -0.5rem;
 	background-color: $vui-color-ferrite;
 	border: 1px solid transparent;
@@ -23,8 +22,9 @@
 	padding: 0.7rem 1rem;
 	z-index: 10;
 
+
 	@include vui-typography-small-text(
-			$color: $vui-color-white, 
+			$color: $vui-color-white,
 			$margin: 0
 		);
 
@@ -36,16 +36,41 @@
 	&::before {
 		border: solid;
 		border-color: $vui-color-ferrite transparent;
-		border-width: 0 0.7rem 0.7rem 0.7rem;
 		content: "";
 		position: absolute;
 		z-index: 10;
 		left: 1rem;
-		top: -0.7rem;
 		[dir='rtl'] & {
 			left: auto;
 			right: 1rem;
 		}
+
+	}
+
+}
+
+@mixin vui-validation-bubble-content() {
+
+	@include vui-validation-bubble-content-base;
+
+	top: 0.25rem;
+
+	&::before {
+		top: -0.7rem;
+		border-width: 0 0.7rem 0.7rem 0.7rem;
+	}
+
+}
+
+@mixin vui-validation-bubble-content-above() {
+
+	@include vui-validation-bubble-content-base;
+
+	bottom: -0.1rem;
+
+	&::before {
+		bottom: -0.7rem;
+		border-width: 0.7rem 0.7rem 0 0.7rem;
 	}
 
 }


### PR DESCRIPTION
Included vui-input as a dev only bower dependency so that test bubbles.html file can include vui-field.  This better demonstrates the offsets that make the bubble above appear in the correct place relative to the input.
